### PR TITLE
Migrer til nais-deploy action og simplifiserer ci/cd fil.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,11 @@ on:
       - "CODEOWNERS"
     branches:
 
+env:
+  IMAGE: docker.pkg.github.com/${{ github.repository }}/pleiepengesoknad-mottak:${{ github.sha }}
+  GITHUB_USERNAME: x-access-token
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   test:
     name: Check Code
@@ -16,14 +21,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
       - name: Check Code
-        env:
-          GITHUB_USERNAME: x-access-token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew check
 
   build-code-and-push-docker:
@@ -34,42 +43,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
       - name: Build JAR
-        env:
-          GITHUB_USERNAME: x-access-token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew shadowJar # Creates a combined JAR of project and runTime dependencies.
-      - name: Create Docker tag
-        env:
-          NAME: pleiepengesoknad-mottak
+      - name: Build and publish Docker image
         run: |
-          echo "docker.pkg.github.com"/"$GITHUB_REPOSITORY"/"$NAME" > .docker_image
-          echo "$(date "+%Y.%m.%d")-$(git rev-parse --short HEAD)" > .docker_tag
-      - name: Build Docker image
-        run: |
-          docker build -t $(cat .docker_image):$(cat .docker_tag) .
-      - name: Login to Github Package Registry
-        env:
-          DOCKER_USERNAME: x-access-token
-          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
-      - name: Push Docker image
-        run: "docker push $(cat .docker_image):$(cat .docker_tag)"
-      - name: pass image file to next job.
-        uses: actions/upload-artifact@v1
-        with:
-          name: docker_image
-          path: .docker_image
-      - name: pass tag file to next job.
-        uses: actions/upload-artifact@v1
-        with:
-          name: docker_tag
-          path: .docker_tag
+          docker build --tag ${IMAGE} .
+          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker push ${IMAGE}
 
   deploy-dev-fss:
     name: Deploy to dev-fss
@@ -77,31 +68,12 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      # Download the image and tag file to use for the deployment cli.
-      - name: Download image file
-        uses: actions/download-artifact@v1
-        with:
-          name: docker_image
-      - name: Download tag file
-        uses: actions/download-artifact@v1
-        with:
-          name: docker_tag
-      - name: unpack
-        run: |
-          cp docker_image/.docker_image .
-          cp docker_tag/.docker_tag .
-      - name: debug
-        run: ls -la
-      - name: deploy to dev-fss
-        uses: navikt/deployment-cli/action@0.4.0
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          cluster: dev-fss
-          team: dusseldorf
-          resources: nais/dev-fss.yml
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-fss
+          RESOURCE: nais/dev-fss.yml
 
   deploy-prod-fss:
     name: Deploy to prod-fss
@@ -109,28 +81,9 @@ jobs:
     needs: build-code-and-push-docker # Depends on build-code-and-push-docker job
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      # Download the image and tag file to use for the deployment cli.
-      - name: Download image file
-        uses: actions/download-artifact@v1
-        with:
-          name: docker_image
-      - name: Download tag file
-        uses: actions/download-artifact@v1
-        with:
-          name: docker_tag
-      - name: unpack
-        run: |
-          cp docker_image/.docker_image .
-          cp docker_tag/.docker_tag .
-      - name: debug
-        run: ls -la
-      - name: deploy to prod-fss
-        uses: navikt/deployment-cli/action@0.4.0
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          cluster: prod-fss
-          team: dusseldorf
-          resources: nais/prod-fss.yml
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-fss
+          RESOURCE: nais/prod-fss.yml

--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -4,9 +4,9 @@ metadata:
   name: pleiepengesoknad-mottak
   namespace: default
   labels:
-    team: {{team}}
+    team: dusseldorf
 spec:
-  image: {{ image }}:{{ tag }}
+  image: {{ image }}
   port: 8080
   liveness:
     path: isalive

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -4,9 +4,9 @@ metadata:
   name: pleiepengesoknad-mottak
   namespace: default
   labels:
-    team: {{team}}
+    team: dusseldorf
 spec:
-  image: {{ image }}:{{ tag }}
+  image: {{ image }}
   port: 8080
   liveness:
     path: isalive


### PR DESCRIPTION
- Erstatter steg for oppbygging av image og tagnavn med å sette det som et miljøvariabel for workflowen.
- Setter teamnavn direkte i nais config, da nais-deploy klager på at den ikke blir satt dersom man bruker {{ team }}.
- Legger til gradle cache som reduserer byggetid betraktelig.

For mer info, se her: https://doc.nais.io/deployment#set-it-up

* Fjerner jobb for trigging av workflow via deployment.
Da nais-deploy bruker samme github api for deployment, fører det til at dette havner i en endeløs loop som deployer om igjen og om igjen.

* Flytter miljøvariabler til globale miljøvariabler i workflow.
Fjerner duplisering, og fører til mindre steder å endre.